### PR TITLE
Directive improvements

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,3 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
-
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
@@ -29,8 +29,6 @@ object AkkaHttpSecurity {
   def authorize(authorizer: Authorizer[CommonProfile])(request: AuthenticatedRequest): Directive0 =
     akkaHttpAuthorize(authorizer.isAuthorized(request.webContext, request.profiles.asJava))
 
-
-
   private def applyHeadersAndCookiesToResponse(changes: ResponseChanges)(httpResponse: HttpResponse): HttpResponse = {
     val regularHeaders: List[HttpHeader] = changes.headers
     val cookieHeaders: List[HttpHeader] = changes.cookies.map(v => `Set-Cookie`(v))

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
@@ -2,28 +2,65 @@ package com.stackstate.pac4j
 
 import java.util
 
+import akka.http.scaladsl.model.HttpHeader.ParsingResult.{ Error, Ok }
+import akka.http.scaladsl.model.{ HttpHeader, HttpResponse }
 import akka.http.scaladsl.server.Directives.{ authorize => akkaHttpAuthorize }
 import akka.http.scaladsl.server.{ Directive0, Directive1, Route, RouteResult }
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.server.RouteResult.Complete
 import com.stackstate.pac4j.AkkaHttpSecurity.AkkaHttpSecurityLogic
+import com.stackstate.pac4j.AkkaHttpWebContext.ResponseChanges
 import com.stackstate.pac4j.http.AkkaHttpActionAdapter
 import org.pac4j.core.authorization.authorizer.Authorizer
 import org.pac4j.core.config.Config
 import org.pac4j.core.engine.{ DefaultSecurityLogic, SecurityLogic }
 import org.pac4j.core.http.adapter.HttpActionAdapter
 import org.pac4j.core.profile.CommonProfile
+import org.pac4j.core.context.Cookie
 
 import scala.collection.JavaConverters._
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.collection.immutable
 
 object AkkaHttpSecurity {
   type AkkaHttpSecurityLogic = SecurityLogic[Future[RouteResult], AkkaHttpWebContext]
 
   def authorize(authorizer: Authorizer[CommonProfile])(request: AuthenticatedRequest): Directive0 =
     akkaHttpAuthorize(authorizer.isAuthorized(request.webContext, request.profiles.asJava))
+
+  private def mapCookie(cookie: Cookie): HttpCookie = {
+    HttpCookie(
+      name = cookie.getName,
+      value = cookie.getValue,
+      expires = None,
+      maxAge = if (cookie.getMaxAge < 0) None else Some(cookie.getMaxAge),
+      domain = Option(cookie.getDomain),
+      path = Option(cookie.getPath),
+      secure = cookie.isSecure,
+      httpOnly = cookie.isHttpOnly,
+      extension = None)
+  }
+
+  private def applyHeadersAndCookiesToResponse(changes: ResponseChanges)(httpResponse: HttpResponse): HttpResponse = {
+    val regularHeaders: List[HttpHeader] =
+      changes.headers
+        .map({
+          case (name, value) => HttpHeader.parse(name, value) match {
+            case Ok(header, _) => header
+            case Error(error) => throw new IllegalArgumentException(s"Error parsing http header ${error.formatPretty}")
+          }
+        })
+
+    val cookieHeaders: List[HttpHeader] = changes.cookies.map(mapCookie).map(v => `Set-Cookie`(v))
+    val additionalHeaders: immutable.Seq[HttpHeader] = regularHeaders ++ cookieHeaders
+
+    httpResponse.mapHeaders(additionalHeaders ++ _)
+  }
 }
 
-class AkkaHttpSecurity[P <: CommonProfile](config: Config) {
+class AkkaHttpSecurity[P <: CommonProfile](config: Config)(implicit val executionContext: ExecutionContext) {
 
+  import AkkaHttpSecurity._
   // TODO: At some point this object should contain the SessionStore (when we implement that)
 
   val securityLogic: AkkaHttpSecurityLogic =
@@ -51,8 +88,10 @@ class AkkaHttpSecurity[P <: CommonProfile](config: Config) {
         securityLogic.perform(context, config, (context: AkkaHttpWebContext, profiles: util.Collection[CommonProfile], parameters: AnyRef) => {
           val authenticatedRequest = AuthenticatedRequest(context, profiles.asScala.toList)
           innerRoute(Tuple1(authenticatedRequest))(ctx)
-          // TODO: Add response headers from the AkkaHttpWebContext and put them into the response
-        }, actionAdapter, clients, "", "", multiProfile)
+        }, actionAdapter, clients, "", "", multiProfile).map[RouteResult] {
+          case Complete(response) => Complete(applyHeadersAndCookiesToResponse(context.getChanges)(response))
+          case rejection => rejection
+        }
       }
     }
 }

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
@@ -1,7 +1,7 @@
 package com.stackstate.pac4j
 
-import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpRequest}
-import org.pac4j.core.context.{Cookie, WebContext}
+import akka.http.scaladsl.model.{ ContentType, ContentTypes, HttpRequest }
+import org.pac4j.core.context.{ Cookie, WebContext }
 
 import scala.collection.JavaConverters._
 
@@ -114,12 +114,12 @@ case class AkkaHttpWebContext(request: HttpRequest) extends WebContext {
 object AkkaHttpWebContext {
 
   //This class is where all the HTTP response changes are stored so that they can later be applied to an HTTP Request
-  case class ResponseChanges private(
-                                      headers: List[(String, String)],
-                                      contentType: ContentType,
-                                      content: String,
-                                      cookies: List[Cookie],
-                                      attributes: Map[String, AnyRef])
+  case class ResponseChanges private (
+    headers: List[(String, String)],
+    contentType: ContentType,
+    content: String,
+    cookies: List[Cookie],
+    attributes: Map[String, AnyRef])
 
   object ResponseChanges {
     def empty: ResponseChanges = {

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
@@ -13,10 +13,13 @@ case class AkkaHttpWebContext(request: HttpRequest, formFields: Seq[(String, Str
   import com.stackstate.pac4j.AkkaHttpWebContext._
 
   private var changes = ResponseChanges.empty
+
+  //Only compute the request cookies once
   private lazy val requestCookies = request.cookies.map { akkaCookie =>
     new Cookie(akkaCookie.name, akkaCookie.value)
   }.asJavaCollection
 
+  //Request parameters are composed of form fields and the query part of the uri. Stored in a lazy val in order to only compute it once
   private lazy val requestParameters = formFields.toMap ++ request.getUri().query().toMap.asScala
 
   override def getRequestCookies: java.util.Collection[Cookie] = requestCookies

--- a/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
+++ b/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
@@ -1,6 +1,6 @@
 package com.stackstate.pac4j.http
 
-import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
 import org.pac4j.core.context.HttpConstants
 import org.pac4j.core.http.adapter.HttpActionAdapter
 import akka.http.scaladsl.model.StatusCodes._
@@ -17,7 +17,7 @@ object AkkaHttpActionAdapter extends HttpActionAdapter[Future[RouteResult], Akka
       case HttpConstants.BAD_REQUEST => HttpResponse(BadRequest)
       case HttpConstants.CREATED => HttpResponse(Created)
       case HttpConstants.FORBIDDEN => HttpResponse(Forbidden)
-      case HttpConstants.OK => HttpResponse(OK) //TODO: Also include the response content in the ok response
+      case HttpConstants.OK => HttpResponse(OK, entity = HttpEntity.apply(context.getResponseContent))
       case HttpConstants.NO_CONTENT => HttpResponse(NoContent)
     }))
   }

--- a/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
+++ b/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
@@ -19,6 +19,7 @@ object AkkaHttpActionAdapter extends HttpActionAdapter[Future[RouteResult], Akka
       case HttpConstants.FORBIDDEN => HttpResponse(Forbidden)
       case HttpConstants.OK => HttpResponse(OK, entity = HttpEntity.apply(context.getContentType, context.getResponseContent.getBytes))
       case HttpConstants.NO_CONTENT => HttpResponse(NoContent)
+      case 500 => HttpResponse(InternalServerError)
     }))
   }
 }

--- a/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
+++ b/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
@@ -1,6 +1,6 @@
 package com.stackstate.pac4j.http
 
-import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
+import akka.http.scaladsl.model.{ HttpEntity, HttpResponse }
 import org.pac4j.core.context.HttpConstants
 import org.pac4j.core.http.adapter.HttpActionAdapter
 import akka.http.scaladsl.model.StatusCodes._
@@ -17,7 +17,7 @@ object AkkaHttpActionAdapter extends HttpActionAdapter[Future[RouteResult], Akka
       case HttpConstants.BAD_REQUEST => HttpResponse(BadRequest)
       case HttpConstants.CREATED => HttpResponse(Created)
       case HttpConstants.FORBIDDEN => HttpResponse(Forbidden)
-      case HttpConstants.OK => HttpResponse(OK, entity = HttpEntity.apply(context.getResponseContent))
+      case HttpConstants.OK => HttpResponse(OK, entity = HttpEntity.apply(context.getContentType, context.getResponseContent.getBytes))
       case HttpConstants.NO_CONTENT => HttpResponse(NoContent)
     }))
   }

--- a/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
+++ b/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
@@ -13,13 +13,22 @@ import scala.concurrent.Future
 object AkkaHttpActionAdapter extends HttpActionAdapter[Future[RouteResult], AkkaHttpWebContext] {
   override def adapt(code: Int, context: AkkaHttpWebContext) = {
     Future.successful(Complete(code match {
-      case HttpConstants.UNAUTHORIZED => HttpResponse(Unauthorized)
-      case HttpConstants.BAD_REQUEST => HttpResponse(BadRequest)
-      case HttpConstants.CREATED => HttpResponse(Created)
-      case HttpConstants.FORBIDDEN => HttpResponse(Forbidden)
-      case HttpConstants.OK => HttpResponse(OK, entity = HttpEntity.apply(context.getContentType, context.getResponseContent.getBytes))
-      case HttpConstants.NO_CONTENT => HttpResponse(NoContent)
-      case 500 => HttpResponse(InternalServerError)
+      case HttpConstants.UNAUTHORIZED =>
+        HttpResponse(Unauthorized)
+      case HttpConstants.BAD_REQUEST =>
+        HttpResponse(BadRequest)
+      case HttpConstants.CREATED =>
+        HttpResponse(Created)
+      case HttpConstants.FORBIDDEN =>
+        HttpResponse(Forbidden)
+      case HttpConstants.OK =>
+        val contentBytes = context.getResponseContent.getBytes
+        val entity = context.getContentType.map(ct => HttpEntity(ct, contentBytes)).getOrElse(HttpEntity(contentBytes))
+        HttpResponse(OK, entity = entity)
+      case HttpConstants.NO_CONTENT =>
+        HttpResponse(NoContent)
+      case 500 =>
+        HttpResponse(InternalServerError)
     }))
   }
 }

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
@@ -1,6 +1,6 @@
 package com.stackstate.pac4j
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, HttpResponse}
 import org.scalatest.{Matchers, WordSpecLike}
 import akka.http.scaladsl.model.StatusCodes._
 import com.stackstate.pac4j.http.AkkaHttpActionAdapter
@@ -11,7 +11,7 @@ class AkkaHttpActionAdapterTest extends WordSpecLike with Matchers with ScalaFut
 
   "AkkaHttpActionAdapter" should {
     "convert 200 to OK" in {
-      AkkaHttpActionAdapter.adapt(200, dummyContext).futureValue.response shouldEqual HttpResponse(OK)
+      AkkaHttpActionAdapter.adapt(200, dummyContext).futureValue.response shouldEqual HttpResponse(OK, Nil, HttpEntity(ContentTypes.`text/plain(UTF-8)`, ""))
     }
     "convert 401 to Unauthorized" in {
       AkkaHttpActionAdapter.adapt(401, dummyContext).futureValue.response shouldEqual HttpResponse(Unauthorized)
@@ -27,6 +27,10 @@ class AkkaHttpActionAdapterTest extends WordSpecLike with Matchers with ScalaFut
     }
     "convert 204 to NoContent" in {
       AkkaHttpActionAdapter.adapt(204, dummyContext).futureValue.response shouldEqual HttpResponse(NoContent)
+    }
+    "convert 200 to OK with content set from the context" in {
+      dummyContext.writeResponseContent("content")
+      AkkaHttpActionAdapter.adapt(200, dummyContext).futureValue.response shouldEqual HttpResponse.apply(OK, Nil, HttpEntity("content"))
     }
   }
 }

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
@@ -1,36 +1,43 @@
 package com.stackstate.pac4j
 
-import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpRequest, HttpResponse }
-import org.scalatest.{ Matchers, WordSpecLike }
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, HttpResponse}
+import org.scalatest.{Matchers, WordSpecLike}
 import akka.http.scaladsl.model.StatusCodes._
+import akka.util.ByteString
 import com.stackstate.pac4j.http.AkkaHttpActionAdapter
 import org.scalatest.concurrent.ScalaFutures
 
 class AkkaHttpActionAdapterTest extends WordSpecLike with Matchers with ScalaFutures {
-  val dummyContext = AkkaHttpWebContext(HttpRequest())
-
   "AkkaHttpActionAdapter" should {
-    "convert 200 to OK" in {
-      AkkaHttpActionAdapter.adapt(200, dummyContext).futureValue.response shouldEqual HttpResponse(OK, Nil, HttpEntity(ContentTypes.`text/plain(UTF-8)`, ""))
+    "convert 200 to OK" in withContext { context =>
+      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse(OK, Nil, HttpEntity(ContentTypes.`application/octet-stream`, ByteString("")))
     }
-    "convert 401 to Unauthorized" in {
-      AkkaHttpActionAdapter.adapt(401, dummyContext).futureValue.response shouldEqual HttpResponse(Unauthorized)
+    "convert 401 to Unauthorized" in withContext { context =>
+      AkkaHttpActionAdapter.adapt(401, context).futureValue.response shouldEqual HttpResponse(Unauthorized)
     }
-    "convert 400 to BadRequest" in {
-      AkkaHttpActionAdapter.adapt(400, dummyContext).futureValue.response shouldEqual HttpResponse(BadRequest)
+    "convert 400 to BadRequest" in withContext { context =>
+      AkkaHttpActionAdapter.adapt(400, context).futureValue.response shouldEqual HttpResponse(BadRequest)
     }
-    "convert 201 to Created" in {
-      AkkaHttpActionAdapter.adapt(201, dummyContext).futureValue.response shouldEqual HttpResponse(Created)
+    "convert 201 to Created" in withContext { context =>
+      AkkaHttpActionAdapter.adapt(201, context).futureValue.response shouldEqual HttpResponse(Created)
     }
-    "convert 403 to Forbidden" in {
-      AkkaHttpActionAdapter.adapt(403, dummyContext).futureValue.response shouldEqual HttpResponse(Forbidden)
+    "convert 403 to Forbidden" in withContext { context =>
+      AkkaHttpActionAdapter.adapt(403, context).futureValue.response shouldEqual HttpResponse(Forbidden)
     }
-    "convert 204 to NoContent" in {
-      AkkaHttpActionAdapter.adapt(204, dummyContext).futureValue.response shouldEqual HttpResponse(NoContent)
+    "convert 204 to NoContent" in withContext { context =>
+      AkkaHttpActionAdapter.adapt(204, context).futureValue.response shouldEqual HttpResponse(NoContent)
     }
-    "convert 200 to OK with content set from the context" in {
-      dummyContext.writeResponseContent("content")
-      AkkaHttpActionAdapter.adapt(200, dummyContext).futureValue.response shouldEqual HttpResponse.apply(OK, Nil, HttpEntity("content"))
+    "convert 200 to OK with content set from the context" in withContext { context =>
+      context.writeResponseContent("content")
+      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse.apply(OK, Nil, HttpEntity(ContentTypes.`application/octet-stream`, ByteString("content")))
     }
+    "convert 200 to OK with content type set from the context" in withContext { context =>
+      context.setResponseContentType("application/json")
+      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse.apply(OK, Nil, HttpEntity(ContentTypes.`application/json`, ByteString("")))
+    }
+  }
+  
+  def withContext(f: AkkaHttpWebContext => Unit) = {
+    f(AkkaHttpWebContext(HttpRequest(), Seq.empty))
   }
 }

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
@@ -1,7 +1,7 @@
 package com.stackstate.pac4j
 
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, HttpResponse}
-import org.scalatest.{Matchers, WordSpecLike}
+import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpRequest, HttpResponse }
+import org.scalatest.{ Matchers, WordSpecLike }
 import akka.http.scaladsl.model.StatusCodes._
 import com.stackstate.pac4j.http.AkkaHttpActionAdapter
 import org.scalatest.concurrent.ScalaFutures

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
@@ -184,7 +184,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
       }
     }
 
-    "failed a request when no parameters exist in a form and enforceFormEncoding is enabled" in {
+    "fail a request when no parameters exist in a form and enforceFormEncoding is enabled" in {
       val config = new Config()
 
       config.setSecurityLogic(new AkkaHttpSecurityLogic {

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
@@ -210,7 +210,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
   "AkkaHttpSecurity.authorize" should {
     "pass the provided authenticationRequest to the authorizer" in {
       val profile = new CommonProfile()
-      val context = AkkaHttpWebContext(HttpRequest())
+      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty)
 
       val route =
         AkkaHttpSecurity.authorize((context: WebContext, profiles: util.List[CommonProfile]) => {
@@ -225,7 +225,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
     }
 
     "reject when authorization fails" in {
-      val context = AkkaHttpWebContext(HttpRequest())
+      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty)
 
       val route =
         AkkaHttpSecurity.authorize((context: WebContext, profiles: util.List[CommonProfile]) => {
@@ -238,7 +238,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
     }
 
     "succeed when authorization succeeded" in {
-      val context = AkkaHttpWebContext(HttpRequest())
+      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty)
 
       val route =
         AkkaHttpSecurity.authorize((context: WebContext, profiles: util.List[CommonProfile]) => {

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
@@ -66,7 +66,7 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
 
     "get/set content type" in withContext() { webContext =>
       webContext.setResponseContentType("application/json")
-      webContext.getContentType shouldEqual ContentTypes.`application/json`
+      webContext.getContentType shouldEqual Some(ContentTypes.`application/json`)
     }
 
     "know if a url is secure" in withContext(scheme = "https") { webContext =>

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
@@ -2,8 +2,9 @@ package com.stackstate.pac4j
 
 import akka.http.scaladsl.model.HttpHeader.ParsingResult.Ok
 import akka.http.scaladsl.model.headers.Cookie
-import akka.http.scaladsl.model.{ HttpHeader, HttpRequest, Uri }
-import org.scalatest.{ Matchers, WordSpecLike }
+import akka.http.scaladsl.model.{ContentTypes, HttpHeader, HttpRequest, Uri}
+import org.scalatest.{Matchers, WordSpecLike}
+
 import scala.collection.JavaConverters._
 
 class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
@@ -60,7 +61,12 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
 
     "get/set response content" in withContext() { webContext =>
       webContext.writeResponseContent("content")
-      webContext.getChanges.content shouldEqual "content"
+      webContext.getResponseContent shouldEqual "content"
+    }
+
+    "get/set content type" in withContext() { webContext =>
+      webContext.setResponseContentType("application/json")
+      webContext.getContentType shouldEqual ContentTypes.`application/json`
     }
 
     "know if a url is secure" in withContext(scheme = "https") { webContext =>

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
@@ -2,8 +2,8 @@ package com.stackstate.pac4j
 
 import akka.http.scaladsl.model.HttpHeader.ParsingResult.Ok
 import akka.http.scaladsl.model.headers.Cookie
-import akka.http.scaladsl.model.{ContentTypes, HttpHeader, HttpRequest, Uri}
-import org.scalatest.{Matchers, WordSpecLike}
+import akka.http.scaladsl.model.{ ContentTypes, HttpHeader, HttpRequest, Uri }
+import org.scalatest.{ Matchers, WordSpecLike }
 
 import scala.collection.JavaConverters._
 

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
@@ -72,6 +72,11 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
     "know if a url is secure" in withContext(scheme = "https") { webContext =>
       webContext.isSecure shouldEqual true
     }
+
+    "return form fields in the request parameters" in withContext(formFields = Seq(("username", "testuser"))) { webContext =>
+      webContext.getRequestParameters.containsKey("username") shouldEqual true
+      webContext.getRequestParameter("username") shouldEqual "testuser"
+    }
   }
 
   def withContext(
@@ -80,12 +85,13 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
     url: String = "",
     scheme: String = "http",
     hostAddress: String = "",
-    hostPort: Int = 0)(f: AkkaHttpWebContext => Unit): Unit = {
+    hostPort: Int = 0,
+    formFields: Seq[(String, String)] = Seq.empty)(f: AkkaHttpWebContext => Unit): Unit = {
     val parsedHeaders: List[HttpHeader] = requestHeaders.map { case (k, v) => HttpHeader.parse(k, v) }.collect { case Ok(header, _) => header }
     val completeHeaders: List[HttpHeader] = parsedHeaders ++ cookies
     val uri = Uri(url).withScheme(scheme).withAuthority(hostAddress, hostPort)
     val request = HttpRequest(uri = uri, headers = completeHeaders)
 
-    f(AkkaHttpWebContext(request))
+    f(AkkaHttpWebContext(request, formFields))
   }
 }


### PR DESCRIPTION
1. Headers, cookies, and body written into the context by pac4j get put into the HttpResponse
2. Add content type to HttpAdapter
3. Support form encoding in the directive
4. Remove sbt formatting plugins