### PR TITLE
Add authorizers to the security logic from the config

### DIFF
--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
@@ -96,7 +96,7 @@ class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage)(implicit 
     * This directive constructs a pac4j context for a route. This means the request is interpreted into
     * an AkkaHttpWebContext and any changes to this context are applied when the route returns (e.g. headers/cookies).
     */
-  def withContext[A](enforceFormEncoding: Boolean): Directive1[AkkaHttpWebContext] =
+  def withContext(enforceFormEncoding: Boolean): Directive1[AkkaHttpWebContext] =
     new Directive1[AkkaHttpWebContext] {
       override def tapply(innerRoute: Tuple1[AkkaHttpWebContext] => Route): Route = { ctx =>
         import ctx.materializer

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
@@ -96,7 +96,7 @@ class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage)(implicit 
     * This directive constructs a pac4j context for a route. This means the request is interpreted into
     * an AkkaHttpWebContext and any changes to this context are applied when the route returns (e.g. headers/cookies).
     */
-  private[pac4j] def withContext[A](enforceFormEncoding: Boolean): Directive1[AkkaHttpWebContext] =
+  def withContext[A](enforceFormEncoding: Boolean): Directive1[AkkaHttpWebContext] =
     new Directive1[AkkaHttpWebContext] {
       override def tapply(innerRoute: Tuple1[AkkaHttpWebContext] => Route): Route = { ctx =>
         import ctx.materializer
@@ -119,6 +119,7 @@ class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage)(implicit 
                           clients: String = null /* Default null, meaning all defined clients */ ,
                           multiProfile: Boolean = true,
                           enforceFormEncoding: Boolean = false, //Force form parameters to be passed for authentication or the request fails
+                          authorizers: String = ""
                         ): Directive1[AuthenticatedRequest] =
     withContext(enforceFormEncoding).flatMap { akkaWebContext =>
       new Directive1[AuthenticatedRequest] {
@@ -126,7 +127,7 @@ class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage)(implicit 
           securityLogic.perform(akkaWebContext, config, (context: AkkaHttpWebContext, profiles: util.Collection[CommonProfile], parameters: AnyRef) => {
             val authenticatedRequest = AuthenticatedRequest(context, profiles.asScala.toList)
             innerRoute(Tuple1(authenticatedRequest))(ctx)
-          }, actionAdapter, clients, "", "", multiProfile)
+          }, actionAdapter, clients, authorizers, "", multiProfile)
         }
       }
     }
@@ -155,6 +156,9 @@ class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage)(implicit 
     }
   }
 
-  def withAllClientsAuthentication(multiProfile: Boolean = true, enforceFormEncoding: Boolean = false): Directive1[AuthenticatedRequest] =
-    withAuthentication(config.getClients.findAllClients().asScala.map(_.getName).mkString(","), multiProfile, enforceFormEncoding)
+  def withAllClientsAuthentication(multiProfile: Boolean = true, enforceFormEncoding: Boolean = false): Directive1[AuthenticatedRequest] = {
+    val authorizers = config.getAuthorizers.keySet().asScala.mkString(",")
+    val clients = config.getClients.findAllClients().asScala.map(_.getName).mkString(",")
+    withAuthentication(clients, multiProfile, enforceFormEncoding, authorizers)
+  }
 }

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
@@ -50,7 +50,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
         override def perform(context: AkkaHttpWebContext, config: Config, securityGrantedAccessAdapter: SecurityGrantedAccessAdapter[Future[RouteResult], AkkaHttpWebContext], httpActionAdapter: HttpActionAdapter[Future[RouteResult], AkkaHttpWebContext], clients: String, authorizers: String, matchers: String, multiProfile: lang.Boolean, parameters: AnyRef*): Future[RouteResult] = {
           clients shouldBe "myclients"
           matchers shouldBe "" // Empty string means always matching hit in RequireAllMatchersChecker.java
-          authorizers shouldBe "" // Empty string means always authorize in DefaultAuthorizationCheck.java
+          authorizers shouldBe "myauthorizers" // Empty string means always authorize in DefaultAuthorizationCheck.java
           multiProfile shouldBe false
 
           httpActionAdapter shouldBe actionAdapter
@@ -60,7 +60,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
 
       val akkaHttpSecurity = new AkkaHttpSecurity(config, new ForgetfulSessionStorage)
 
-      Get("/") ~> akkaHttpSecurity.withAuthentication("myclients", multiProfile = false) { _ => complete("problem!") } ~> check {
+      Get("/") ~> akkaHttpSecurity.withAuthentication("myclients", multiProfile = false, authorizers = "myauthorizers") { _ => complete("problem!") } ~> check {
         status shouldEqual StatusCodes.OK
         responseAs[String] shouldBe "called!"
       }


### PR DESCRIPTION
Add authorizers from the config

Make the withContext function public in order to mix-in custom directive that require the webContext. An example is the CSRF token generation directive, which is a StackState custom directive, that needs the webcontext in order to get the sessionStore to store tokens.