### PR TITLE
Avoid setting duplicate headers in the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,47 @@
 ## akka-http-pac4j ##
 A wrapper around pac4j (www.pac4j.org) built using AkkaHTTP
 
-## publishing
+## One time publishing configuration
 
-- Follow the procedure on: https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html
+- Set Sonatype account information
+    - Place in `$HOME/.sbt/(sbt-version 0.13 or 1.0)/sonatype.sbt` the following configuration:
+    ```
+    credentials += Credentials("Sonatype Nexus Repository Manager",
+            "oss.sonatype.org",
+            "(Sonatype user name)",
+            "(Sonatype password)")
+    ```
+    - Create a PGP key pair:
+        - `sbt pgp-cmd gen-key` which should generate an output like...        
+        ```
+        Please enter the name associated with the key: Developer
+        Please enter the email associated with the key: developer@gmail.com
+        Please enter the passphrase for the key: ***************
+        Please re-enter the passphrase for the key: ***************
+        [info] Creating a new PGP key, this could take a long time.
+        [info] Public key := /Users/developer/.sbt/gpg/pubring.asc
+        [info] Secret key := /Users/developer/.sbt/gpg/secring.asc
+        [info] Please do not share your secret key.   Your public key is free to share.
+        ```
+    - Send your key to a public Key Server
+        - Obtain your key id using `sbt pgp-cmd list-keys` which should output...
+        ```
+        /Users/developer/.sbt/gpg/pubring.asc
+        -------------------------------------
+        pub	RSA@2048/2bb8c19d	2018-12-03
+        uid	                	Developer <developer@gmail.com>
+         ```
+         - Export your key using `sbt pgp-cmd send-key 2bb8c19d hkp://keyserver.ubuntu.com`
+         ```
+         Sending PublicKeyRing(PublicKey(9884fa162bb8c19d, Developer <developer@gmail.com>, RSA@2048)) to HkpServer(http://keyserver.ubuntu.com:11371)
+         ```
+- Support links
+    - https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html
+    - https://www.scala-sbt.org/sbt-pgp/usage.html
+
+## Publishing artifacts
+- Modify the version in `build.sbt`. If the project version has "SNAPSHOT" suffix, your project will be published to the snapshot repository of Sonatype 
+    ```
+    version      := "0.4.1-SNAPSHOT"
+    ```
+- Publish using `sbt publishSigned`

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file(".")).
     inThisBuild(List(
       organization := "com.stackstate",
       scalaVersion := "2.12.4",
-      version      := "0.4.0"
+      version      := "0.4.1"
     )),
     name := "akka-http-pac4j",
     libraryDependencies ++= Seq(

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
@@ -58,7 +58,7 @@ object AkkaHttpSecurity {
       if (enforceFormEncoding) {
         Future.failed(e)
       } else {
-        Future.successful(Seq.empty)
+        Future.successful(immutable.Seq.empty)
       }
     }
   }


### PR DESCRIPTION
Improvement to avoid setting duplicate headers in the response and to allow reusing an existing akka http web context during callback resolution. This is useful when we mix directives with our callback route to avoid creating multiple sessionId's