### PR TITLE
Make session cookie name configurable

### DIFF
--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
@@ -64,7 +64,7 @@ object AkkaHttpSecurity {
   }
 }
 
-class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage)(implicit val executionContext: ExecutionContext) {
+class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage, val sessionCookieName: String = AkkaHttpWebContext.DEFAULT_COOKIE_NAME)(implicit val executionContext: ExecutionContext) {
 
   import AkkaHttpSecurity._
 
@@ -98,7 +98,7 @@ class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage)(implicit 
     */
   def withContext(existingContext: Option[AkkaHttpWebContext] = None, formParams: Map[String, String] = Map.empty): Directive1[AkkaHttpWebContext] =
     Directive[Tuple1[AkkaHttpWebContext]] { inner => ctx =>
-      val akkaWebContext = existingContext.getOrElse(AkkaHttpWebContext(ctx.request, formParams.toSeq, sessionStorage))
+      val akkaWebContext = existingContext.getOrElse(AkkaHttpWebContext(ctx.request, formParams.toSeq, sessionStorage, sessionCookieName = sessionCookieName))
       inner(Tuple1(akkaWebContext))(ctx).map[RouteResult] {
         case Complete(response) => Complete(applyHeadersAndCookiesToResponse(akkaWebContext.getChanges)(response))
         case rejection => rejection

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
@@ -19,7 +19,9 @@ import scala.collection.JavaConverters._
  */
 case class AkkaHttpWebContext(request: HttpRequest,
                               formFields: Seq[(String, String)],
-                              private[pac4j] val sessionStorage: SessionStorage) extends WebContext {
+                              private[pac4j] val sessionStorage: SessionStorage,
+                              sessionCookieName: String
+                             ) extends WebContext {
   import com.stackstate.pac4j.AkkaHttpWebContext._
 
   private var changes = ResponseChanges.empty
@@ -40,7 +42,7 @@ case class AkkaHttpWebContext(request: HttpRequest,
 
   private[pac4j] var sessionId: String =
     request.cookies
-      .filter(_.name == COOKIE_NAME)
+      .filter(_.name == sessionCookieName)
       .map(_.value)
       .find(session => sessionStorage.sessionExists(session))
       .getOrElse(newSession())
@@ -168,7 +170,7 @@ case class AkkaHttpWebContext(request: HttpRequest,
   def getChanges: ResponseChanges = changes
 
   def addResponseSessionCookie(): Unit = {
-    val cookie = new Cookie(COOKIE_NAME, sessionId)
+    val cookie = new Cookie(sessionCookieName, sessionId)
     cookie.setSecure(isSecure)
     cookie.setMaxAge(sessionStorage.sessionLifetime.toSeconds.toInt)
     cookie.setHttpOnly(true)
@@ -195,5 +197,5 @@ object AkkaHttpWebContext {
     }
   }
 
-  private[pac4j] val COOKIE_NAME = "AkkaHttpPac4jSession"
+  private[pac4j] val DEFAULT_COOKIE_NAME = "AkkaHttpPac4jSession"
 }

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
@@ -42,6 +42,6 @@ class AkkaHttpActionAdapterTest extends WordSpecLike with Matchers with ScalaFut
   }
   
   def withContext(f: AkkaHttpWebContext => Unit) = {
-    f(AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage))
+    f(AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage, AkkaHttpWebContext.DEFAULT_COOKIE_NAME))
   }
 }

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
@@ -202,7 +202,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
 
     "run the callbackLogic reusing an akka http context" in {
       val config = new Config()
-      val existingContext = AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage)
+      val existingContext = AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage, AkkaHttpWebContext.DEFAULT_COOKIE_NAME)
 
       val actionAdapter = new HttpActionAdapter[HttpResponse, AkkaHttpWebContext] {
         override def adapt(code: Int, context: AkkaHttpWebContext): HttpResponse = ???
@@ -235,7 +235,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
   "AkkaHttpSecurity.authorize" should {
     "pass the provided authenticationRequest to the authorizer" in {
       val profile = new CommonProfile()
-      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage)
+      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage, AkkaHttpWebContext.DEFAULT_COOKIE_NAME)
 
       val route =
         AkkaHttpSecurity.authorize((context: WebContext, profiles: util.List[CommonProfile]) => {
@@ -250,7 +250,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
     }
 
     "reject when authorization fails" in {
-      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage)
+      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage, AkkaHttpWebContext.DEFAULT_COOKIE_NAME)
 
       val route =
         AkkaHttpSecurity.authorize((context: WebContext, profiles: util.List[CommonProfile]) => {
@@ -263,7 +263,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
     }
 
     "succeed when authorization succeeded" in {
-      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage)
+      val context = AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage, AkkaHttpWebContext.DEFAULT_COOKIE_NAME)
 
       val route =
         AkkaHttpSecurity.authorize((context: WebContext, profiles: util.List[CommonProfile]) => {

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
@@ -96,9 +96,9 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
       override def renewSession(session: SessionKey): Boolean = true
     }) { webContext =>
       webContext.addResponseSessionCookie()
-      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.COOKIE_NAME) shouldBe Some(
+      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.DEFAULT_COOKIE_NAME) shouldBe Some(
         HttpCookie(
-          name = AkkaHttpWebContext.COOKIE_NAME,
+          name = AkkaHttpWebContext.DEFAULT_COOKIE_NAME,
           value = webContext.sessionId,
           expires = None,
           maxAge = Some(3),
@@ -113,7 +113,7 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
     "don't add a cookie when the session was expired" in withContext(sessionStorage = new ForgetfulSessionStorage {
       override def renewSession(session: SessionKey): Boolean = false
     }) { webContext =>
-      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.COOKIE_NAME) shouldBe None
+      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.DEFAULT_COOKIE_NAME) shouldBe None
     }
 
     "make the session cookie secure when running over https" in withContext(scheme = "https", sessionStorage = new ForgetfulSessionStorage {
@@ -121,11 +121,11 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
       override def renewSession(session: SessionKey): Boolean = true
     }) { webContext =>
       webContext.addResponseSessionCookie()
-      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.COOKIE_NAME).get.secure shouldBe true
+      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.DEFAULT_COOKIE_NAME).get.secure shouldBe true
     }
 
     "pick up the session cookie and send it back" in withContext(
-      cookies = List(Cookie(AkkaHttpWebContext.COOKIE_NAME, "my_session")),
+      cookies = List(Cookie(AkkaHttpWebContext.DEFAULT_COOKIE_NAME, "my_session")),
       sessionStorage = new ForgetfulSessionStorage {
         override val sessionLifetime = 3.seconds
         override def sessionExists(key: SessionKey): Boolean = true
@@ -133,11 +133,11 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
       }
     ) { webContext =>
       webContext.addResponseSessionCookie()
-      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.COOKIE_NAME).isDefined shouldEqual true
+      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.DEFAULT_COOKIE_NAME).isDefined shouldEqual true
     }
 
     "pick up the session cookie from cookies that are no longer sessions" in withContext(
-      cookies = List(Cookie(AkkaHttpWebContext.COOKIE_NAME, "some_session"), Cookie(AkkaHttpWebContext.COOKIE_NAME, "my_session")),
+      cookies = List(Cookie(AkkaHttpWebContext.DEFAULT_COOKIE_NAME, "some_session"), Cookie(AkkaHttpWebContext.DEFAULT_COOKIE_NAME, "my_session")),
       sessionStorage = new ForgetfulSessionStorage {
         override val sessionLifetime = 3.seconds
         override def sessionExists(key: SessionKey): Boolean = key == "my_session"
@@ -145,11 +145,11 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
       }
     ) { webContext =>
       webContext.addResponseSessionCookie()
-      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.COOKIE_NAME).get.value shouldEqual "my_session"
+      webContext.getChanges.cookies.find(_.name == AkkaHttpWebContext.DEFAULT_COOKIE_NAME).get.value shouldEqual "my_session"
     }
 
     "creates a new sessionId when the cookie was expired" in withContext(
-      cookies = List(Cookie(AkkaHttpWebContext.COOKIE_NAME, "my_session")),
+      cookies = List(Cookie(AkkaHttpWebContext.DEFAULT_COOKIE_NAME, "my_session")),
       sessionStorage = new ForgetfulSessionStorage {
         override val sessionLifetime = 3.seconds
         override def sessionExists(key: SessionKey): Boolean = false
@@ -160,7 +160,7 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
     }
 
     "creates a new sessionId when the session was destroyed" in withContext(
-      cookies = List(Cookie(AkkaHttpWebContext.COOKIE_NAME, "my_session")),
+      cookies = List(Cookie(AkkaHttpWebContext.DEFAULT_COOKIE_NAME, "my_session")),
       sessionStorage = new ForgetfulSessionStorage {
         override val sessionLifetime = 3.seconds
         override def renewSession(session: SessionKey): Boolean = true
@@ -171,7 +171,7 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
     }
 
     "stores the trackable session when requested" in withContext(
-      cookies = List(Cookie(AkkaHttpWebContext.COOKIE_NAME, "my_session")),
+      cookies = List(Cookie(AkkaHttpWebContext.DEFAULT_COOKIE_NAME, "my_session")),
       sessionStorage = new ForgetfulSessionStorage {
         override val sessionLifetime = 3.seconds
         override def renewSession(session: SessionKey): Boolean = true
@@ -196,6 +196,6 @@ class AkkaHttpWebContextTest extends WordSpecLike with Matchers {
     val uri = Uri(url).withScheme(scheme).withAuthority(hostAddress, hostPort)
     val request = HttpRequest(uri = uri, headers = completeHeaders)
 
-    f(AkkaHttpWebContext(request, formFields, sessionStorage))
+    f(AkkaHttpWebContext(request, formFields, sessionStorage, AkkaHttpWebContext.DEFAULT_COOKIE_NAME))
   }
 }

--- a/src/test/scala/com/stackstate/pac4j/http/AkkaHttpSessionStoreTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/http/AkkaHttpSessionStoreTest.scala
@@ -11,13 +11,13 @@ class AkkaHttpSessionStoreTest extends WordSpecLike with Matchers with Scalatest
   "AkkaHttpSessionStore.get" should {
     "return null when the data is not available" in {
       new AkkaHttpSessionStore().get(
-        new AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage),
+        new AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage, AkkaHttpWebContext.DEFAULT_COOKIE_NAME),
         "mykey"
       ) shouldBe null
     }
 
     "return the data when available" in {
-      val context = new AkkaHttpWebContext(HttpRequest(), Seq.empty, new InMemorySessionStorage(30.minutes))
+      val context = new AkkaHttpWebContext(HttpRequest(), Seq.empty, new InMemorySessionStorage(30.minutes), AkkaHttpWebContext.DEFAULT_COOKIE_NAME)
       new AkkaHttpSessionStore().set(context, "mykey", "yooo")
       new AkkaHttpSessionStore().get(context, "mykey") shouldBe "yooo"
     }


### PR DESCRIPTION
current cookie name `AkkaHttpPac4jSession` reveals too much info about backend without a good reason, so make cookie name configurable.