### PR TITLE
Duplicate headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ log/
 **/idea_build
 out/
 
+# Metals
+**/metals.sbt
+**/.metals
+
 # Sublime
 *.sublime*
 *.sublime-project

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 lazy val root = (project in file(".")).settings(
-  inThisBuild(List(organization := "com.stackstate", scalaVersion := "2.12.4", version := "0.4.6")),
+  inThisBuild(List(organization := "com.stackstate", scalaVersion := "2.12.11", version := "0.4.6")),
   name := "akka-http-pac4j",
   libraryDependencies ++= Seq(akkaHttp, akkaStream, pac4j, scalaTestCore % Test, scalacheck % Test, akkaHttpTestKit % Test, akkaStreamTestKit % Test),
   scalacOptions ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.3.8

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
@@ -14,12 +14,11 @@ import scala.collection.JavaConverters._
 
 /**
   *
- * The AkkaHttpWebContext is responsible for wrapping an HTTP request and stores changes that are produced by pac4j and
- * need to be applied to an HTTP response.
- */
-case class AkkaHttpWebContext(request: HttpRequest,
-                              formFields: Seq[(String, String)],
-                              private[pac4j] val sessionStorage: SessionStorage) extends WebContext {
+  * The AkkaHttpWebContext is responsible for wrapping an HTTP request and stores changes that are produced by pac4j and
+  * need to be applied to an HTTP response.
+  */
+case class AkkaHttpWebContext(request: HttpRequest, formFields: Seq[(String, String)], private[pac4j] val sessionStorage: SessionStorage)
+    extends WebContext {
   import com.stackstate.pac4j.AkkaHttpWebContext._
 
   private var changes = ResponseChanges.empty
@@ -69,7 +68,8 @@ case class AkkaHttpWebContext(request: HttpRequest,
       path = Option(cookie.getPath),
       secure = cookie.isSecure,
       httpOnly = cookie.isHttpOnly,
-      extension = None)
+      extension = None
+    )
   }
 
   override def addResponseCookie(cookie: Cookie): Unit = {
@@ -89,7 +89,8 @@ case class AkkaHttpWebContext(request: HttpRequest,
       case Error(error) => throw new IllegalArgumentException(s"Error parsing http header ${error.formatPretty}")
     }
 
-    changes = changes.copy(headers = changes.headers ++ List(header))
+    // Avoid adding duplicate headers, Pac4J expects to overwrite headers like `Location`
+    changes = changes.copy(headers = header :: changes.headers.filter(_.name != name))
   }
 
   override def getRequestParameters: java.util.Map[String, Array[String]] = {
@@ -182,12 +183,11 @@ case class AkkaHttpWebContext(request: HttpRequest,
 object AkkaHttpWebContext {
 
   //This class is where all the HTTP response changes are stored so that they can later be applied to an HTTP Request
-  case class ResponseChanges private (
-                                       headers: List[HttpHeader],
-                                       contentType: Option[ContentType],
-                                       content: String,
-                                       cookies: List[HttpCookie],
-                                       attributes: Map[String, AnyRef])
+  case class ResponseChanges private (headers: List[HttpHeader],
+                                      contentType: Option[ContentType],
+                                      content: String,
+                                      cookies: List[HttpCookie],
+                                      attributes: Map[String, AnyRef])
 
   object ResponseChanges {
     def empty: ResponseChanges = {


### PR DESCRIPTION
Pac4j sometimes sets headers twice. For example the Location header is set multiple times in the OIDC logout flow. To be compatible with this behavior headers need to be overwritten instead of added