### PR TITLE
Forbidden sometimes needs session cookie

### DIFF
--- a/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
+++ b/src/main/scala/com/stackstate/pac4j/http/AkkaHttpActionAdapter.scala
@@ -14,6 +14,9 @@ object AkkaHttpActionAdapter extends HttpActionAdapter[Future[RouteResult], Akka
   override def adapt(code: Int, context: AkkaHttpWebContext): Future[Complete] = {
     Future.successful(Complete(code match {
       case HttpConstants.UNAUTHORIZED =>
+        // XHR requests don't receive a TEMP_REDIRECT but a UNAUTHORIZED. The client can handle this
+        // to trigger the proper redirect anyway, but for a correct flow the session cookie must be set
+        context.addResponseSessionCookie()
         HttpResponse(Unauthorized)
       case HttpConstants.BAD_REQUEST =>
         HttpResponse(BadRequest)

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpActionAdapterTest.scala
@@ -11,13 +11,19 @@ import org.scalatest.concurrent.ScalaFutures
 class AkkaHttpActionAdapterTest extends WordSpecLike with Matchers with ScalaFutures {
   "AkkaHttpActionAdapter" should {
     "convert 200 to OK" in withContext { context =>
-      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse(OK, Nil, HttpEntity(ContentTypes.`application/octet-stream`, ByteString("")))
+      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse(
+        OK,
+        Nil,
+        HttpEntity(ContentTypes.`application/octet-stream`, ByteString(""))
+      )
     }
     "convert 401 to Unauthorized" in withContext { context =>
       AkkaHttpActionAdapter.adapt(401, context).futureValue.response shouldEqual HttpResponse(Unauthorized)
+      context.getChanges.cookies.map(_.name) shouldBe List(AkkaHttpWebContext.DEFAULT_COOKIE_NAME)
     }
     "convert 302 to SeeOther (to support login flow)" in withContext { context =>
       AkkaHttpActionAdapter.adapt(302, context).futureValue.response shouldEqual HttpResponse(SeeOther)
+      context.getChanges.cookies.map(_.name) shouldBe List(AkkaHttpWebContext.DEFAULT_COOKIE_NAME)
     }
     "convert 400 to BadRequest" in withContext { context =>
       AkkaHttpActionAdapter.adapt(400, context).futureValue.response shouldEqual HttpResponse(BadRequest)
@@ -33,14 +39,16 @@ class AkkaHttpActionAdapterTest extends WordSpecLike with Matchers with ScalaFut
     }
     "convert 200 to OK with content set from the context" in withContext { context =>
       context.writeResponseContent("content")
-      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse.apply(OK, Nil, HttpEntity(ContentTypes.`application/octet-stream`, ByteString("content")))
+      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse
+        .apply(OK, Nil, HttpEntity(ContentTypes.`application/octet-stream`, ByteString("content")))
     }
     "convert 200 to OK with content type set from the context" in withContext { context =>
       context.setResponseContentType("application/json")
-      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse.apply(OK, Nil, HttpEntity(ContentTypes.`application/json`, ByteString("")))
+      AkkaHttpActionAdapter.adapt(200, context).futureValue.response shouldEqual HttpResponse
+        .apply(OK, Nil, HttpEntity(ContentTypes.`application/json`, ByteString("")))
     }
   }
-  
+
   def withContext(f: AkkaHttpWebContext => Unit) = {
     f(AkkaHttpWebContext(HttpRequest(), Seq.empty, new ForgetfulSessionStorage, AkkaHttpWebContext.DEFAULT_COOKIE_NAME))
   }


### PR DESCRIPTION
Ajax requests can be used for indirect authentication but then they must have a session id cookie otherwise the callback verification will fail.