### PR TITLE
Fetch tags in publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Fetching full history is required for snapshot publishing to set correct version number.