### PR TITLE
STAC-17136. Fix problem with sessionId

### DIFF
--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpSecurity.scala
@@ -180,8 +180,8 @@ class AkkaHttpSecurity(config: Config, sessionStorage: SessionStorage, val sessi
         _ =>
           callbackLogic.perform(akkaWebContext, config, actionAdapter, defaultUrl, saveInSession, multiProfile, true, defaultClient.orNull).map {
             result =>
-              akkaWebContext.addResponseSessionCookie()
               if (setCsrfCookie) akkaWebContext.addResponseCsrfCookie()
+              akkaWebContext.addResponseSessionCookie()
               result
           }
       }

--- a/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
+++ b/src/main/scala/com/stackstate/pac4j/AkkaHttpWebContext.scala
@@ -40,6 +40,7 @@ class AkkaHttpWebContext(val request: HttpRequest,
     .find(_.name == sessionCookieName)
     .map(_.value)
     .filter(_.nonEmpty)
+    .find(session => sessionStorage.sessionExists(session))
 
   def getOrCreateSessionId(): String = {
     val newSession =

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpWebContextTest.scala
@@ -266,6 +266,28 @@ class AkkaHttpWebContextTest extends AnyWordSpecLike with Matchers {
 
       webContext.getChanges.cookies shouldBe List(validCookie)
     }
+
+    "when getSessionId is called and the session exists in the store should return it" in withContext(
+      cookies = List(Cookie(AkkaHttpWebContext.DEFAULT_COOKIE_NAME, "validId")),
+      sessionStorage = new ForgetfulSessionStorage {
+        override val sessionLifetime = 3.seconds
+
+        override def sessionExists(sessionKey: SessionKey): Boolean = true
+      }
+    ) { webContext =>
+      webContext.getSessionId shouldBe Some("validId")
+    }
+
+    "when getSessionId is called and the session doesn't exists in the store should return None" in withContext(
+      cookies = List(Cookie(AkkaHttpWebContext.DEFAULT_COOKIE_NAME, "notValidAnyMore")),
+      sessionStorage = new ForgetfulSessionStorage {
+        override val sessionLifetime = 3.seconds
+
+        override def sessionExists(sessionKey: SessionKey): Boolean = false
+      }
+    ) { webContext =>
+      webContext.getSessionId shouldBe None
+    }
   }
 
   def withContext(requestHeaders: List[(String, String)] = List.empty,


### PR DESCRIPTION
STAC-17136

## Change description
Fix problem sessionId was not always validated if it was in the store. Swap the order of when the CSRF cookie was added in login callback to guarantee a valid sessionId is returned during login process.

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
